### PR TITLE
using qemu-offical recommended way to redirection ssh ports during startup VM

### DIFF
--- a/run-qemu.sh
+++ b/run-qemu.sh
@@ -99,6 +99,6 @@ if [ $KERNEL != prebuild ]; then
 	esac
 fi
 
-FULLCMD="$CMD -kernel $BZIMAGE $IMAGEPATH $INITRDPATH $GRAPHICS -redir tcp:2222::22 --enable-kvm -append \"$ROOTAPPEND console=ttyS0 vga=0x0343\""
+FULLCMD="$CMD -kernel $BZIMAGE $IMAGEPATH $INITRDPATH $GRAPHICS -device e1000,netdev=enp2s0 -netdev user,id=enp2s0,hostfwd=tcp::2222-:22 --enable-kvm -append \"$ROOTAPPEND console=ttyS0 vga=0x0343\""
 echo "$FULLCMD"
 eval $FULLCMD


### PR DESCRIPTION
Dear maintainer,

The old method like "-redir tcp:2222::22" is deprecated.

[As qemu wiki informed](https://wiki.qemu.org/Documentation/Networking#How_to_get_SSH_access_to_a_guest), the latest redirection way is like:
-device e1000,netdev=net0
-netdev user,id=net0,hostfwd=tcp::5555-:22 